### PR TITLE
Allow non-aligned PSTR()

### DIFF
--- a/newlib/libc/sys/xtensa/sys/pgmspace.h
+++ b/newlib/libc/sys/xtensa/sys/pgmspace.h
@@ -31,12 +31,16 @@ extern "C" {
   #define PGM_VOID_P         const void *
 #endif
 
-// PSTR() macro modified to start on a 32-bit boundary.  This adds on average
-// 1.5 bytes/string, but in return memcpy_P and strcpy_P will work 4~8x faster
+#ifndef PSTR_ALIGN
+  // PSTR() macro starts by default on a 32-bit boundary.  This adds on average
+  // 1.5 bytes/string, but in return memcpy_P and strcpy_P will work 4~8x faster
+  // Allow users to override the alignment with PSTR_ALIGN
+  #define PSTR_ALIGN 4
+#endif
 #ifndef PSTR
     // Adapted from AVR-specific code at https://forum.arduino.cc/index.php?topic=194603.0
     // Uses C attribute section instead of ASM block to allow for C language string concatenation ("x" "y" === "xy")
-    #define PSTR(s) (__extension__({static const char __pstr__[] __attribute__((__aligned__(4))) __attribute__((section( "\".irom0.pstr." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\", \"aSM\", @progbits, 1 #"))) = (s); &__pstr__[0];}))
+    #define PSTR(s) (__extension__({static const char __c[] __attribute__((__aligned__(PSTR_ALIGN))) __attribute__((section( "\".irom0.pstr." __FILE__ "." __STRINGIZE(__LINE__) "."  __STRINGIZE(__COUNTER__) "\", \"aSM\", @progbits, 1 #"))) = (s); &__c[0];}))
 #endif
 
 // Flash memory must be read using 32 bit aligned addresses else a processor


### PR DESCRIPTION
Report PR https://github.com/esp8266/Arduino/pull/7275

Reporting the code from Arduino repo, also changed `__pstr__` to `__c`. Is this change ok?