### PR TITLE
Avoid void pointer arithmetic

### DIFF
--- a/newlib/libc/sys/xtensa/sys/pgmspace.h
+++ b/newlib/libc/sys/xtensa/sys/pgmspace.h
@@ -123,7 +123,7 @@ static inline double pgm_read_double_unaligned(const void* addr) {
     uint32_t i[2];
   } u;
   pgm_read_dword_with_offset(addr, u.i[0]);
-  pgm_read_dword_with_offset(addr + 4, u.i[1]);
+  pgm_read_dword_with_offset((char *)addr + 4, u.i[1]);
   return u.res;
 }
 


### PR DESCRIPTION
Avoid void pointer arithmetic in pgm_read_double_unaligned(), by casting it to a char-pointer before doing arithmetic. Generated code is identical.

The background for this is that void pointer arithmetic is a GNU extension, that clang doesn't allow at all in C++ mode. This precludes running clang-based static analyzers (such as clang-tidy) on any files that include pgmspace.h, which is unfortunate.