### PR TITLE
sys/pgmspace.h: fix dangerous behavior of #20

### DIFF
--- a/newlib/libc/sys/xtensa/sys/pgmspace.h
+++ b/newlib/libc/sys/xtensa/sys/pgmspace.h
@@ -89,7 +89,7 @@ extern "C" {
     "ssa8l\t%4\n\t"        /* SAR = (AR[`addr`] & 3) * 8; */ \
     "src\t%0, %2, %1\n\t"  /* AR[`res`(lo)] = (AR[`midword`] << 32 | AR[`loword`]) >> SAR; */ \
     "src\t%D0, %3, %2"     /* AR[`res`(hi)] = (AR[`hiword`] << 32 | AR[`midword`]) >> SAR; */ \
-    : "=a"(res) : "r"(loword), "r"(midword), "r"(hiword), "r"(addr))
+    : "=&a"(res) : "r"(loword), "r"(midword), "r"(hiword), "r"(addr))
 
 // Literature: Xtensa(R) Instruction Set Reference Manual,
 //               "SRC - Shift Right Combined" [p.528], "SRL - Shift Right Logical" [p.529]


### PR DESCRIPTION
in `__pgm_extract_qword()`, input operands may accidentally be overwritten before used.

Literature: Using the GNU Compiler Collection; For gcc version 10.3.0, "6.47.3.3 Constraint Modifier Characters"

for example:
```
#include <sys/pgmspace.h>
double test(unsigned high, void* addr, unsigned int low, unsigned int mid) {
  double res;
  __pgm_extract_qword(low, mid, high, addr, res);
  return res;
}
```
```
	.file	"test.c"
	.text
	.literal_position
	.align	4
	.global	test
	.type	test, @function
test:
#APP
# 5 "test.c" 1
	ssa8l	a3
	src	a2, a5, a4	// here!
	src	a3, a2, a5
# 0 "" 2
#NO_APP
	ret.n
	.size	test, .-test
	.ident	"GCC: (GNU) 10.3.0"
```
